### PR TITLE
hotfix for truncated comments

### DIFF
--- a/mod_app/admin/film_admin.py
+++ b/mod_app/admin/film_admin.py
@@ -86,14 +86,16 @@ class FilmAdmin(admin.ModelAdmin):
     # these fields show html tags from the ckeditor otherwise
     def safe_synopsis(self, obj):
         truncated_synopsis = truncatechars_html(obj.synopsis, 200)
-        return format_html(truncated_synopsis)
+        modified_synopsis = truncated_synopsis.replace("{", "(").replace("}", ")")
+        return format_html(modified_synopsis)
 
     safe_synopsis.allow_tags = True
     safe_synopsis.short_description = "Synopsis"
 
     def safe_comments(self, obj):
         truncated_comments = truncatechars_html(obj.comments, 200)
-        return format_html(truncated_comments)
+        modified_comments = truncated_comments.replace("{", "(").replace("}", ")")
+        return format_html(modified_comments)
 
     safe_comments.allow_tags = True
     safe_comments.short_description = "Comments"

--- a/mod_app/admin/teaching_analysis_admin.py
+++ b/mod_app/admin/teaching_analysis_admin.py
@@ -79,7 +79,8 @@ class AnalysisAdmin(admin.ModelAdmin):
 
     def safe_content(self, obj):
         truncated_content = truncatechars_html(obj.content, 200)
-        return format_html(truncated_content)
+        modified_content = truncated_content.replace("{", "(").replace("}", ")")
+        return format_html(modified_content)
 
     safe_content.allow_tags = True
     safe_content.short_description = "Content"

--- a/museum_of_dreams_project/settings/aws.py
+++ b/museum_of_dreams_project/settings/aws.py
@@ -13,6 +13,7 @@ ENVIRONMENT = "production"
 ALLOWED_HOSTS = [
     "museumofdreamworlds.eu-west-2.elasticbeanstalk.com",
     "museumofdreamworlds.org",
+    os.environ.get("PIP"),
 ]
 
 DATABASES = {

--- a/museum_of_dreams_project/settings/base.py
+++ b/museum_of_dreams_project/settings/base.py
@@ -29,13 +29,13 @@ ENVIRONMENT = "local"
 INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "grappelli.dashboard",
-    "grappelli",
+    "grappelli",  # needs to be before admin
+    "mod_app",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
-    "mod_app",
     "ckeditor",
     "ckeditor_uploader",
     "django_distill",

--- a/museum_of_dreams_project/settings/base.py
+++ b/museum_of_dreams_project/settings/base.py
@@ -28,14 +28,14 @@ ENVIRONMENT = "local"
 
 INSTALLED_APPS = [
     "django.contrib.contenttypes",
-    "grappelli.dashboard",
+    "grappelli.dashboard",  # should be before grappelli and after content types
     "grappelli",  # needs to be before admin
-    "mod_app",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "mod_app",
     "ckeditor",
     "ckeditor_uploader",
     "django_distill",

--- a/museum_of_dreams_project/settings/staging.py
+++ b/museum_of_dreams_project/settings/staging.py
@@ -5,6 +5,7 @@ ENVIRONMENT = "staging"
 ALLOWED_HOSTS = [
     "museumofdreams.eu-west-2.elasticbeanstalk.com",
     "staging.museumofdreamworlds.org",
+    os.environ.get("PIP"),
 ]
 GRAPPELLI_ADMIN_TITLE = "Museum of Dreams"
 AWS_STORAGE_BUCKET_NAME = "moddevbucket"

--- a/museum_of_dreams_project/urls.py
+++ b/museum_of_dreams_project/urls.py
@@ -1,28 +1,15 @@
 """
 URL configuration for museum_of_dreams_project project.
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/4.2/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  path('', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.urls import include, path
-    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.conf import settings
 from django.conf.urls import include
 from django.conf.urls.static import static
 from django.contrib import admin
-from django.http import HttpResponse
 from django.urls import path
-from django_distill import distill_path
-from django.views.generic.base import RedirectView
 
+# from django.views.generic.base import RedirectView
+
+from django_distill import distill_path
 
 from mod_app import views
 
@@ -44,7 +31,7 @@ urlpatterns = (
         distill_path(
             "", views.HomeView.as_view(), name="home", distill_file="index.html"
         ),
-        path("favicon.ico", RedirectView.as_view(url="static/admin/img/favicon.ico")),
+        # path("favicon.ico", RedirectView.as_view(url="static/admin/img/favicon.ico")),
         path("mentions-api", views.MentionsApiView.as_view(), name="mentions_api"),
         # website pages
         distill_path(

--- a/museum_of_dreams_project/urls.py
+++ b/museum_of_dreams_project/urls.py
@@ -7,7 +7,7 @@ from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import path
 
-# from django.views.generic.base import RedirectView
+from django.views.generic.base import RedirectView
 
 from django_distill import distill_path
 
@@ -31,7 +31,10 @@ urlpatterns = (
         distill_path(
             "", views.HomeView.as_view(), name="home", distill_file="index.html"
         ),
-        # path("favicon.ico", RedirectView.as_view(url="static/admin/img/favicon.ico")),
+        path(
+            "favicon.ico",
+            RedirectView.as_view(url=f"{settings.STATIC_URL}admin/img/favicon.ico"),
+        ),
         path("mentions-api", views.MentionsApiView.as_view(), name="mentions_api"),
         # website pages
         distill_path(


### PR DESCRIPTION
Truncated versions interpreted {} as variable to be substituted, so have replaced with (). This doesn't affect the actual content in the full version.