### PR TITLE
Feature/cdk database

### DIFF
--- a/docs/aws/cdk/first-time-setup.md
+++ b/docs/aws/cdk/first-time-setup.md
@@ -8,24 +8,42 @@ Before starting, you will need to have the following installed:
 - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
 - [AWS CDK CLI](https://docs.aws.amazon.com/cdk/v2/guide/cli.html)
 
-Once these are in place, you can start working by:
+Optional, but highly recommended:
 
-```bash
-$ cd infrastructure # ensures that you are working from the cdk project directory
+- Installing the AWS Toolkit extension for VSCode users
 
-# installing the python cdk libraries
-$ pip install -r requirement.txt
-$ pip install -r requirement-dev.txt
-```
+### Using SSO connections & profiles
 
-The `cdk` command should be now callable in your terminal given you are in the correct working directory.
-
-## Note
-
-For the Museum of Dreamworlds Project, the cdk directory would be `/infrastructure`. In other cases, it will usually be where app.py is located in your cdk project.
-
-## Setting up profile (wip)
+While it is fine to run `aws configure` to set up a local CDK profile with access keys, for federated users, the recommended way is to set up an SSO connection instead:
 
 ```bash
 $ aws configure sso
 ```
+
+You will be prompted the following:
+
+```bash
+SSO session name (Recommended): # give a name for this connection
+SSO start URL [None]: # provide your AWS access portal link
+SSO region [None]: # provide your account region
+SSO registration scopes [sso:account:access]: # customises the scope of this session, use the default value "sso:account:access" for this unless instructed otherwise
+```
+
+### Example configuration for UCL accounts:
+
+```bash
+SSO session name (Recommended): UCL
+SSO start URL [None]: https://ucl-cloud.awsapps.com/start
+SSO region [None]: eu-west-2
+SSO registration scopes [sso:account:access]: sso:account:access
+```
+
+This will open you browser to login/authorise access to Application and AWS account. After doing so, in your terminal, you can select the profile you will be using for CDK deploymnets.
+
+### IMPORTANT NOTE(s):
+
+- In order to successfully deploy a CloudFormation Stack, make sure your AWS account have enough permissions - this can be checked from your AWS account access portal.
+
+## Next steps
+
+[Getting started with AWS CDK](./getting-started-with-cdk.md)

--- a/docs/aws/cdk/first-time-setup.md
+++ b/docs/aws/cdk/first-time-setup.md
@@ -10,7 +10,7 @@ Before starting, you will need to have the following installed:
 
 Optional, but highly recommended:
 
-- Installing the AWS Toolkit extension for VSCode users
+- Installing the AWS Toolkit extension (if using VSCode)
 
 ### Using SSO connections & profiles
 

--- a/docs/aws/cdk/first-time-setup.md
+++ b/docs/aws/cdk/first-time-setup.md
@@ -22,7 +22,7 @@ The `cdk` command should be now callable in your terminal given you are in the c
 
 ## Note
 
-For the Museum of Dreamworlds Project, the cdk directory would be `/infrastructure`, but in other cases, it will usually where app.py is located in your cdk project
+For the Museum of Dreamworlds Project, the cdk directory would be `/infrastructure`. In other cases, it will usually be where app.py is located in your cdk project.
 
 ## Setting up profile (wip)
 

--- a/docs/aws/cdk/getting-started-with-cdk.md
+++ b/docs/aws/cdk/getting-started-with-cdk.md
@@ -1,0 +1,17 @@
+# Getting started with AWS CDK
+
+Once these are in place, you can start working by:
+
+```bash
+$ cd infrastructure # ensures that you are working from the cdk project directory
+
+# installing the python cdk libraries
+$ pip install -r requirement.txt
+$ pip install -r requirement-dev.txt
+```
+
+The `cdk` command should be now callable in your terminal given you are in the correct working directory.
+
+## Note
+
+For the Museum of Dreamworlds Project, the cdk directory would be `/infrastructure`. In other cases, it will usually be where app.py is located in your cdk project.

--- a/docs/aws/cdk/getting-started-with-cdk.md
+++ b/docs/aws/cdk/getting-started-with-cdk.md
@@ -1,6 +1,7 @@
 # Getting started with AWS CDK
 
-Once these are in place, you can start working by:
+Once you've completed the steps in
+[First time setup](./first-time-setup.md), you can start using the Cloud Development Kit in Museum of Dreamworlds by running the following:
 
 ```bash
 $ cd infrastructure # ensures that you are working from the cdk project directory

--- a/docs/aws/cdk/infrastructure/database.md
+++ b/docs/aws/cdk/infrastructure/database.md
@@ -1,39 +1,95 @@
-# Relational Database Service
+# Relational Database Service Stack
 
-RDS stacks should be deployed after VPC stack and before Elastic Beanstalk environments, this is because the Elastic Beanstalk Stack will need information from the database to use as environment variables.
+## Important:
 
-## Security Group:
+- RDS stacks should be deployed after VPC stack and before Elastic Beanstalk environments, this is because the Elastic Beanstalk Stack will need to use database credentials as environment variables.
 
-Security group for both database and elastic beanstalk environment are set up in `database_stack.py`
+- Security group for both `database` and `elastic beanstalk environment` are created inside `database_stack.py`
+
+## Official AWS documentation/ resources (Python)
+
+- [AWS API reference for RDS](https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_rds.html)
+- [Examples/ parameters for DatabaseInstance construct](https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_rds/DatabaseInstance.html)
 
 ## Defining a database instance:
 
 ```python
-from aws_cdk aws_rds as rds
+from aws_cdk import aws_rds as rds
 
 rds.DatabaseInstance(
     self,
-    "CdkSQLDatabase",
+    "CdkSQLDatabase", # The database construct ID, must be unique relative to the scope of
     # include any additional parameters
 )
 ```
 
-View [Official AWS doc on DatabaseInstance](https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_rds/DatabaseInstance.html) for parameters options
-
 ## Example configuration:
 
-Below is a list of parameters we have used for configuring a database instance:
+Below is the configuration we have used to set up a minimal MySQL instance:
 
-- `database_name`: your database name (Only alpha-numeric characters allowed)
-- `engine`: database engine type (e.g. `rds.DatabaseInstanceEngine.mysql`)
-- `version`: databse engine version ( e.g. `rds.MysqlEngineVersion.VER_8_0_41`)
-- `credentials`: `rds.Credentials.from_generated_secret("admin")`(this uses aws secret manager which generates credentials like username/password automatically),
-- `vpc`: select the vpc the database will be using,
-- `vpc_subnets`: select the subnets the databse will be using (e.g. `ec2.SubnetSelection(subnet_type=ec2.SubnetType.PRIVATE_WITH_EGRESS)`)
-- `instance_type`: chooses the database instance type, related with performance (e.g. `ec2.InstanceType.of(ec2.InstanceClass.BURSTABLE4_GRAVITON, ec2.InstanceSize.MICRO)`)
-- `allocated_storage`: specific the capacity of the database in GiB (e.g.`20`)
-- `security_groups`: select the security group the database will be using (e.g.)`[self.database_sg]`
-- `publicly_accessible`: should be set to `False` at all time for security
-- `deletion_protection`: Prevents users from deleting the database. Set to `False` for staging, `True` for production
-- `multi_az`: specify number of availability zones to host in. Set to `False` for single availability zone.
-- `parameters`: additional parameters for the database itself`{"sql_mode": "STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION"}`
+### Engine, hardware settings:
+
+```python
+self.db_instance = rds.DatabaseInstance(
+            self,
+            id="CdkSQLDatabase", # sets database ID
+            database_name="CdkSQLDatabase", # sets database's display name
+
+            engine=rds.DatabaseInstanceEngine.mysql(
+                version=rds.MysqlEngineVersion.VER_8_0_41
+            ), # sets engine type to MySQL, and version to 8.0.41
+
+            instance_type=ec2.InstanceType.of(
+                ec2.InstanceClass.BURSTABLE4_GRAVITON, ec2.InstanceSize.MICRO
+            ), # sets database instance class to db.t4g.micro
+
+            allocated_storage=20, # sets storage capacity to 20 GiB
+```
+
+### Credential generation
+
+```python
+            credentials=rds.Credentials.from_generated_secret("admin"),
+            # this generates a username (admin) and a password in aws secret manager for the database
+```
+
+### VPC, security settings
+
+```python
+            vpc=vpc, # select the vpc
+            vpc_subnets=ec2.SubnetSelection(
+                subnet_type=ec2.SubnetType.PRIVATE_WITH_EGRESS
+            ), # assigns database instance to private subnets within your vpc
+
+            security_groups=[self.database_sg], # selects the security group(s) for the instance
+            publicly_accessible=False, # disable public access for security purposes
+```
+
+### Miscellaneous settings
+
+```python
+            removal_policy=RemovalPolicy.DESTROY,
+            # enables database items to be deleted along with the database itself
+            deletion_protection=False, # enables quick database deletion
+            multi_az=False, # uses a single availability zone for the instance
+            parameters={"sql_mode": "STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION"}, # enables StrictMode for MySQL
+        )
+
+```
+
+## Parameters notes:
+
+- `id`: specifies a construct id for the instance - this must be unique within the Relational Database Service scope.
+- `database_name`: your database name as shown (is restricted to only alpha-numeric characters)
+- `engine`: database engine type (e.g. `PostgreSQL`,`MySQL`)
+- `version`: database engine version (e.g. `8.0.41`)
+- `instance_type`: the compute name and memory capacity (e.g `db.t4g.micro`)
+- `allocated_storage`: specify the capacity of the database in `gibibytes(GiB)`
+- `credentials`: your database's root admin information (usually a username and a generated password from secrets manager)
+- `vpc`: selects the vpc the database will be using
+- `vpc_subnets`: selects the subnets the database will be using
+- `security_groups`: selects the security group the database will be using
+- `publicly_accessible`: should be set to `False` at all time for security purposes
+- `deletion_protection`: prevents users from deleting the database. Should be set to `False` for staging, `True` for production
+- `multi_az`: specifies if the database instance is a multiple Availability Zone deployment
+- `parameters`: you can configure additional parameters for the database itself (e.g. enable StrictMode for MySQL)

--- a/docs/aws/cdk/infrastructure/database.md
+++ b/docs/aws/cdk/infrastructure/database.md
@@ -1,0 +1,39 @@
+# Relational Database Service
+
+RDS stacks should be deployed after VPC stack and before Elastic Beanstalk environments, this is because the Elastic Beanstalk Stack will need information from database to use as environment variables.
+
+## Security Group:
+
+Security group for both database and elastic beanstalk environment are setup in `database_stack.py`
+
+## Defining a database instance:
+
+```python
+from aws_cdk aws_rds as rds
+
+rds.DatabaseInstance(
+    self,
+    "CdkSQLDatabase",
+    # include any additional parameters
+)
+```
+
+View [Official AWS doc on DatabaseInstance](https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_rds/DatabaseInstance.html) for parameters options
+
+## Example configuration:
+
+Below is a list of example parameters for configuring a database instance:
+
+- `database_name`: your database name (Only alpha-numeric characters allowed)
+- `engine`: database engine type (e.g. `rds.DatabaseInstanceEngine.mysql`)
+- `version`: databse engine version ( e.g. `rds.MysqlEngineVersion.VER_8_0_41`)
+- `credentials`: `rds.Credentials.from_generated_secret("admin")`(this uses aws secret manager which generates credentials like username/password automatically),
+- `vpc`: select the vpc the database will be using,
+- `vpc_subnets`: select the subnets the databse will be using (e.g. `ec2.SubnetSelection(subnet_type=ec2.SubnetType.PRIVATE_WITH_EGRESS)`)
+- `instance_type`: chooses the database instance type, related with performance (e.g. `ec2.InstanceType.of(ec2.InstanceClass.BURSTABLE4_GRAVITON, ec2.InstanceSize.MICRO)`)
+- `allocated_storage`: specific the capacity of the database in GiB (e.g.`20`)
+- `security_groups`: select the security group the database will be using (e.g.)`[self.database_sg]`
+- `publicly_accessible`: should be set to `False` at all time for security
+- `deletion_protection`: Prevents users from deleting the database. Set to `False` for staging, `True` for production
+- `multi_az`: specify number of availability zones to host in. Set to `False` for single availability zone.
+- `parameters`: additional parameters for the database itself`{"sql_mode": "STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION"}`

--- a/docs/aws/cdk/infrastructure/database.md
+++ b/docs/aws/cdk/infrastructure/database.md
@@ -9,7 +9,7 @@
 ## Official AWS documentation/ resources (Python)
 
 - [AWS API reference for RDS](https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_rds.html)
-- [Examples/ parameters for DatabaseInstance construct](https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_rds/DatabaseInstance.html)
+- [Examples/ parameters for the DatabaseInstance construct](https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_rds/DatabaseInstance.html)
 
 ## Defining a database instance:
 
@@ -80,7 +80,7 @@ self.db_instance = rds.DatabaseInstance(
 ## Parameters notes:
 
 - `id`: specifies a construct id for the instance - this must be unique within the Relational Database Service scope.
-- `database_name`: your database name as shown (is restricted to only alpha-numeric characters)
+- `database_name`: your database name as shown (restricted to only alpha-numeric characters)
 - `engine`: database engine type (e.g. `PostgreSQL`,`MySQL`)
 - `version`: database engine version (e.g. `8.0.41`)
 - `instance_type`: the compute name and memory capacity (e.g `db.t4g.micro`)

--- a/docs/aws/cdk/infrastructure/database.md
+++ b/docs/aws/cdk/infrastructure/database.md
@@ -18,7 +18,7 @@ from aws_cdk import aws_rds as rds
 
 rds.DatabaseInstance(
     self,
-    "CdkSQLDatabase", # The database construct ID, must be unique relative to the scope of
+    "CdkSQLDatabase", # provide a construct ID for your database
     # include any additional parameters
 )
 ```

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -6,6 +6,7 @@
 
 - [CDK Infrastructure Overview](./aws/cdk/overview.md)
 - [First Time Setup](./aws/cdk/first-time-setup.md)
+- [Gettings Started with AWS CDK](./aws/cdk/getting-started-with-cdk.md)
 
 ### Infrastructure
 

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -6,3 +6,8 @@
 
 - [CDK Infrastructure Overview](./aws/cdk/overview.md)
 - [First Time Setup](./aws/cdk/first-time-setup.md)
+
+### Infrastructure
+
+- [VPC Stack](./aws/cdk/infrastructure/vpc.md)
+- [Database Stack](./aws/cdk/infrastructure/database.md)

--- a/infrastructure/app.py
+++ b/infrastructure/app.py
@@ -6,14 +6,8 @@ from stacks.database_stack import DatabaseStack
 
 app = cdk.App()
 
-vpc_stack = VPCStack(
-    app,
-    "CdkVPCStack",
-)
+vpc_stack = VPCStack(app, "CdkVPCStack")
 
-database_stack = DatabaseStack(
-    app,
-    "CdkDatabaseStack",
-)
+database_stack = DatabaseStack(app, "CdkDatabaseStack", vpc=vpc_stack.vpc)
 
 app.synth()

--- a/infrastructure/app.py
+++ b/infrastructure/app.py
@@ -6,7 +6,16 @@ from stacks.staging_database_stack import StagingDatabaseStack
 
 app = cdk.App()
 
-vpc_stack = VPCStack(app, "VPCStack")
-database_stack = StagingDatabaseStack(app, "StagingDbStack", vpc=vpc_stack.vpc)
+vpc_stack = VPCStack(
+    app,
+    "VPCStack",
+    description="Stack for VPC, sets up a VPC network that is used in RDS & EB stacks",
+)
+database_stack = StagingDatabaseStack(
+    app,
+    "StagingDbStack",
+    description="Stack for staging database(can be deleted), also contains relevant security groups for RDS & EB",
+    vpc=vpc_stack.vpc,
+)
 
 app.synth()

--- a/infrastructure/app.py
+++ b/infrastructure/app.py
@@ -2,12 +2,18 @@
 
 import aws_cdk as cdk
 from stacks.vpc_stack import VPCStack
+from stacks.database_stack import DatabaseStack
 
 app = cdk.App()
 
 vpc_stack = VPCStack(
     app,
     "CdkVPCStack",
+)
+
+database_stack = DatabaseStack(
+    app,
+    "CdkDatabaseStack",
 )
 
 app.synth()

--- a/infrastructure/app.py
+++ b/infrastructure/app.py
@@ -6,8 +6,7 @@ from stacks.database_stack import DatabaseStack
 
 app = cdk.App()
 
-vpc_stack = VPCStack(app, "CdkVPCStack")
-
-database_stack = DatabaseStack(app, "CdkDatabaseStack", vpc=vpc_stack.vpc)
+vpc_stack = VPCStack(app, "VPCStack")
+database_stack = DatabaseStack(app, "StagingDbStack", vpc=vpc_stack.vpc)
 
 app.synth()

--- a/infrastructure/app.py
+++ b/infrastructure/app.py
@@ -2,11 +2,11 @@
 
 import aws_cdk as cdk
 from stacks.vpc_stack import VPCStack
-from stacks.database_stack import DatabaseStack
+from stacks.staging_database_stack import StagingDatabaseStack
 
 app = cdk.App()
 
 vpc_stack = VPCStack(app, "VPCStack")
-database_stack = DatabaseStack(app, "StagingDbStack", vpc=vpc_stack.vpc)
+database_stack = StagingDatabaseStack(app, "StagingDbStack", vpc=vpc_stack.vpc)
 
 app.synth()

--- a/infrastructure/stacks/database_stack.py
+++ b/infrastructure/stacks/database_stack.py
@@ -33,6 +33,10 @@ class DatabaseStack(Stack):
             ec2.Peer.any_ipv4(), ec2.Port.tcp(80)
         )  # allow public access
 
+        self.elasticbeanstalk_sg.add_ingress_rule(
+            ec2.Peer.any_ipv4(), ec2.Port.tcp(443), "Allow HTTPS"
+        )
+
         # Database
         self.database_sg = ec2.SecurityGroup(
             self,

--- a/infrastructure/stacks/database_stack.py
+++ b/infrastructure/stacks/database_stack.py
@@ -1,0 +1,15 @@
+from aws_cdk import (
+    aws_ec2 as ec2,
+)
+
+from constructs import Construct
+
+
+class DatabaseStack:
+    def __init__(
+        self, scope: Construct, construct_id: str, env_vpc: ec2.IVpc, **kwargs
+    ) -> None:
+        super.__init__(scope, construct_id, **kwargs)
+
+        # Security group for RDS
+        rds_sg = ec2.SecurityGroup(self, "RDSInstanceSG", vpc=env_vpc)

--- a/infrastructure/stacks/database_stack.py
+++ b/infrastructure/stacks/database_stack.py
@@ -1,13 +1,18 @@
-from aws_cdk import aws_ec2 as ec2, aws_rds as rds, RemovalPolicy
+from aws_cdk import (
+    Stack,
+    aws_ec2 as ec2,
+    aws_rds as rds,
+    RemovalPolicy,
+)
 
 from constructs import Construct
 
 
-class DatabaseStack:
+class DatabaseStack(Stack):
     def __init__(
         self, scope: Construct, construct_id: str, env_vpc: ec2.IVpc, **kwargs
     ) -> None:
-        super.__init__(scope, construct_id, **kwargs)
+        super().__init__(scope, construct_id, **kwargs)
 
         # Security group for RDS
         rds_sg = ec2.SecurityGroup(self, "RDSInstanceSG", vpc=env_vpc)
@@ -16,7 +21,7 @@ class DatabaseStack:
             self,
             "CdkSQLDatabase",
             engine=rds.DatabaseInstanceEngine.mysql(
-                "version=rds.MysqlEngineVersion.VER_8_0_34"
+                version=rds.MysqlEngineVersion.VER_8_0_39
             ),
             credentials=rds.Credentials.from_generated_secret("admin"),
             vpc=env_vpc,

--- a/infrastructure/stacks/database_stack.py
+++ b/infrastructure/stacks/database_stack.py
@@ -72,4 +72,5 @@ class DatabaseStack(Stack):
             removal_policy=RemovalPolicy.DESTROY,
             deletion_protection=False,
             multi_az=False,
+            parameters={"sql_mode": "STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION"},
         )

--- a/infrastructure/stacks/database_stack.py
+++ b/infrastructure/stacks/database_stack.py
@@ -26,7 +26,12 @@ class DatabaseStack(Stack):
             "CDkElasticBeanstalkSG",
             vpc=vpc,
             security_group_name="CdkElasticBeanstalkSG",
+            allow_all_outbound=True,
         )
+
+        self.elasticbeanstalk_sg.add_ingress_rule(
+            ec2.Peer.any_ipv4(), ec2.Port.tcp(80)
+        )  # allow public access
 
         # Database
         self.database_sg = ec2.SecurityGroup(

--- a/infrastructure/stacks/database_stack.py
+++ b/infrastructure/stacks/database_stack.py
@@ -1,6 +1,4 @@
-from aws_cdk import (
-    aws_ec2 as ec2,
-)
+from aws_cdk import aws_ec2 as ec2, aws_rds as rds, RemovalPolicy
 
 from constructs import Construct
 
@@ -13,3 +11,25 @@ class DatabaseStack:
 
         # Security group for RDS
         rds_sg = ec2.SecurityGroup(self, "RDSInstanceSG", vpc=env_vpc)
+
+        rds.DatabaseInstance(
+            self,
+            "CdkSQLDatabase",
+            engine=rds.DatabaseInstanceEngine.mysql(
+                "version=rds.MysqlEngineVersion.VER_8_0_34"
+            ),
+            credentials=rds.Credentials.from_generated_secret("admin"),
+            vpc=env_vpc,
+            instance_type=ec2.InstanceType.of(
+                ec2.InstanceClass.BURSTABLE3, ec2.InstanceSize.MICRO
+            ),
+            allocated_storage=20,
+            vpc_subnets=ec2.SubnetSelection(
+                subnet_type=ec2.SubnetType.PRIVATE_WITH_EGRESS
+            ),
+            security_groups=[rds_sg],
+            publicly_accessible=False,
+            removal_policy=RemovalPolicy.DESTROY,
+            deletion_protection=False,
+            multi_az=False,
+        )

--- a/infrastructure/stacks/database_stack.py
+++ b/infrastructure/stacks/database_stack.py
@@ -40,7 +40,7 @@ class DatabaseStack(Stack):
             self.elasticbeanstalk_sg, ec2.Port.tcp(3306), "Allow EB access to MySQL"
         )
 
-        self.database_name = "cdk-sql-db"
+        self.database_name = "CdkDatabase"
 
         self.db_instance = rds.DatabaseInstance(
             self,

--- a/infrastructure/stacks/database_stack.py
+++ b/infrastructure/stacks/database_stack.py
@@ -26,11 +26,12 @@ class DatabaseStack(Stack):
         #     ec2.Port.tcp(3306),
         #     "Allow EB access to MySQL",
         # )
+        self.database_name = "cdk-sql-db"
 
-        rds.DatabaseInstance(
+        self.db_instance = rds.DatabaseInstance(
             self,
             "CdkSQLDatabase",
-            database_name="mod-cdk-db",
+            database_name=self.database_name,
             engine=rds.DatabaseInstanceEngine.mysql(
                 version=rds.MysqlEngineVersion.VER_8_0_41
             ),

--- a/infrastructure/stacks/database_stack.py
+++ b/infrastructure/stacks/database_stack.py
@@ -51,7 +51,7 @@ class DatabaseStack(Stack):
 
         self.database_sg.add_ingress_rule(
             peer=self.elasticbeanstalk_sg,
-            port=ec2.Port.tcp(3306),
+            connection=ec2.Port.tcp(3306),
             description="Allow inbound access of the database from the ElasticBeanstalk security group",
         )
 

--- a/infrastructure/stacks/database_stack.py
+++ b/infrastructure/stacks/database_stack.py
@@ -13,29 +13,29 @@ class DatabaseStack(Stack):
         self,
         scope: Construct,
         construct_id: str,
-        env_vpc: ec2.IVpc,
-        eb_sg: ec2.ISecurityGroup,
+        vpc: ec2.IVpc,
         **kwargs,
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
         # Security group for RDS
-        rds_sg = ec2.SecurityGroup(self, "RDSInstanceSG", vpc=env_vpc)
+        rds_sg = ec2.SecurityGroup(self, "RDSInstanceSG", vpc=vpc)
 
-        rds_sg.add_ingress_rule(
-            eb_sg,
-            ec2.Port.tcp(3306),
-            "Allow EB access to MySQL",
-        )
+        # rds_sg.add_ingress_rule(
+        #     eb_sg,
+        #     ec2.Port.tcp(3306),
+        #     "Allow EB access to MySQL",
+        # )
 
         rds.DatabaseInstance(
             self,
             "CdkSQLDatabase",
+            database_name="mod-cdk-db",
             engine=rds.DatabaseInstanceEngine.mysql(
                 version=rds.MysqlEngineVersion.VER_8_0_41
             ),
             credentials=rds.Credentials.from_generated_secret("admin"),
-            vpc=env_vpc,
+            vpc=vpc,
             instance_type=ec2.InstanceType.of(
                 ec2.InstanceClass.BURSTABLE4_GRAVITON, ec2.InstanceSize.MICRO
             ),

--- a/infrastructure/stacks/database_stack.py
+++ b/infrastructure/stacks/database_stack.py
@@ -60,7 +60,7 @@ class DatabaseStack(Stack):
 
         self.db_instance = rds.DatabaseInstance(
             self,
-            "CdkSQLDatabase",
+            "CdkDatabase",
             database_name=self.database_name,
             engine=rds.DatabaseInstanceEngine.mysql(
                 version=rds.MysqlEngineVersion.VER_8_0_41

--- a/infrastructure/stacks/database_stack.py
+++ b/infrastructure/stacks/database_stack.py
@@ -10,23 +10,34 @@ from constructs import Construct
 
 class DatabaseStack(Stack):
     def __init__(
-        self, scope: Construct, construct_id: str, env_vpc: ec2.IVpc, **kwargs
+        self,
+        scope: Construct,
+        construct_id: str,
+        env_vpc: ec2.IVpc,
+        eb_sg: ec2.ISecurityGroup,
+        **kwargs,
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
         # Security group for RDS
         rds_sg = ec2.SecurityGroup(self, "RDSInstanceSG", vpc=env_vpc)
 
+        rds_sg.add_ingress_rule(
+            eb_sg,
+            ec2.Port.tcp(3306),
+            "Allow EB access to MySQL",
+        )
+
         rds.DatabaseInstance(
             self,
             "CdkSQLDatabase",
             engine=rds.DatabaseInstanceEngine.mysql(
-                version=rds.MysqlEngineVersion.VER_8_0_39
+                version=rds.MysqlEngineVersion.VER_8_0_41
             ),
             credentials=rds.Credentials.from_generated_secret("admin"),
             vpc=env_vpc,
             instance_type=ec2.InstanceType.of(
-                ec2.InstanceClass.BURSTABLE3, ec2.InstanceSize.MICRO
+                ec2.InstanceClass.BURSTABLE4_GRAVITON, ec2.InstanceSize.MICRO
             ),
             allocated_storage=20,
             vpc_subnets=ec2.SubnetSelection(

--- a/infrastructure/stacks/staging_database_stack.py
+++ b/infrastructure/stacks/staging_database_stack.py
@@ -8,7 +8,7 @@ from aws_cdk import (
 from constructs import Construct
 
 
-class DatabaseStack(Stack):
+class StagingDatabaseStack(Stack):
     def __init__(
         self,
         scope: Construct,
@@ -43,10 +43,10 @@ class DatabaseStack(Stack):
         # Setting up Security Group for MySQL, adding appropriate ingress rules
         self.database_sg = ec2.SecurityGroup(
             self,
-            "CdkDatabaseSG",
+            "StagingDatabaseSG",
             vpc=vpc,
-            security_group_name="CdkDatabaseSG",
-            description="Security Group for CdkDatabase, created via CDK",
+            security_group_name="StagingDatabaseSG",
+            description="Security Group for StagingDatabase, created via CDK",
         )
 
         self.database_sg.add_ingress_rule(
@@ -56,11 +56,11 @@ class DatabaseStack(Stack):
         )
 
         # Defining MySQL database
-        self.database_name = "CdkDatabase"
+        self.database_name = "StagingDatabase"
 
         self.db_instance = rds.DatabaseInstance(
             self,
-            "CdkDatabase",
+            "StagingDatabase",
             database_name=self.database_name,
             engine=rds.DatabaseInstanceEngine.mysql(
                 version=rds.MysqlEngineVersion.VER_8_0_41


### PR DESCRIPTION
Closes: #199 
Related to #195

- Sets up a security group each for the Database and the Elastic Beanstalk environment
- Adds ingress rules for EB security group to allow all inbound traffic from Ipv4
- Adds ingress rule for Database security group to allow only inbound access from Elastic Beanstalk
- Generate database credentials (username, password) and store in AWS secret manager

~~Note: need to update doc for database_stack.py~~