### PR TITLE
Patch/analysis content tab size

### DIFF
--- a/mod_app/static/css/film.css
+++ b/mod_app/static/css/film.css
@@ -160,7 +160,7 @@
   }
 }
 
-@media screen and (min-width: 767px) and (max-width: 1000px) {
+@media screen and (min-width: 767px) and (max-width: 992px) {
   #filmic {
     .film__video {
       width: 450px;

--- a/mod_app/static/css/film.css
+++ b/mod_app/static/css/film.css
@@ -46,14 +46,6 @@
   grid-column: 2;
 }
 
-.columnar-area {
-  grid-column: 1;
-  position: sticky;
-  align-self: start;
-  top: 0;
-  left: 0;
-}
-
 .film__content-wrapper {
   /* padding: 1rem; */
   display: flex;

--- a/mod_app/static/css/film.css
+++ b/mod_app/static/css/film.css
@@ -136,10 +136,6 @@
   .film__content-wrapper {
     grid-column: 1/-1;
   }
-  .columnar-area {
-    position: static;
-    grid-template-columns: 1/-1;
-  }
 
   #filmic {
     .film__video {

--- a/mod_app/static/css/tabbed-area.css
+++ b/mod_app/static/css/tabbed-area.css
@@ -13,6 +13,13 @@
     margin-bottom: 2rem;
   }
 } */
+.columnar-area {
+  grid-column: 1;
+  position: sticky;
+  align-self: start;
+  top: 0;
+  left: 0;
+}
 
 .tabbed-area {
   display: flex;

--- a/mod_app/static/css/tabbed-area.css
+++ b/mod_app/static/css/tabbed-area.css
@@ -68,6 +68,10 @@ body:has(.tab-selection.is-sticky) .tab-selection {
 }
 
 @media screen and (max-width: 767px) {
+  .columnar-area {
+    position: static;
+    grid-template-columns: 1/-1;
+  }
   .tab-selection {
     flex-wrap: wrap;
   }
@@ -86,8 +90,8 @@ body:has(.tab-selection.is-sticky) .tab-selection {
 @media screen and (min-width: 767px) and (max-width: 992px) {
   .active[name="content"] {
     img {
-      max-width: 500px;
-      max-height: 100% !important;
+      max-width: 200px;
+      max-height: 500px;
       object-fit: contain;
     }
   }
@@ -96,8 +100,8 @@ body:has(.tab-selection.is-sticky) .tab-selection {
 @media screen and (min-width: 992px) and (max-width: 1200px) {
   .active[name="content"] {
     img {
-      max-width: 700px;
-      max-height: 100% !important;
+      max-width: 250px;
+      max-height: 600px;
       object-fit: contain;
     }
   }

--- a/mod_app/static/css/tabbed-area.css
+++ b/mod_app/static/css/tabbed-area.css
@@ -3,7 +3,7 @@
   position: sticky;
   align-self: start;
   top: 0;
-  left: 0;
+  left: auto; /*auto prevents sticky menu on the x-axis when scrolling horizontally*/
 }
 
 .tabbed-area {

--- a/mod_app/static/css/tabbed-area.css
+++ b/mod_app/static/css/tabbed-area.css
@@ -91,7 +91,7 @@ body:has(.tab-selection.is-sticky) .tab-selection {
   .active[name="content"] {
     img {
       max-width: 200px;
-      max-height: 500px;
+      max-height: 250px;
       object-fit: contain;
     }
   }
@@ -101,7 +101,7 @@ body:has(.tab-selection.is-sticky) .tab-selection {
   .active[name="content"] {
     img {
       max-width: 250px;
-      max-height: 600px;
+      max-height: 300px;
       object-fit: contain;
     }
   }

--- a/mod_app/static/css/tabbed-area.css
+++ b/mod_app/static/css/tabbed-area.css
@@ -1,18 +1,3 @@
-/* .columnar-area {
-  position: sticky;
-  top: 1rem;
-
-  img {
-    width: 100% !important;
-    height: auto !important;
-    max-width: 100% !important;
-    object-fit: contain;
-  }
-
-  .info > div {
-    margin-bottom: 2rem;
-  }
-} */
 .columnar-area {
   grid-column: 1;
   position: sticky;

--- a/mod_app/static/css/tabbed-area.css
+++ b/mod_app/static/css/tabbed-area.css
@@ -90,8 +90,8 @@ body:has(.tab-selection.is-sticky) .tab-selection {
 @media screen and (min-width: 767px) and (max-width: 992px) {
   .active[name="content"] {
     img {
-      max-width: 200px;
-      max-height: 250px;
+      max-width: 500px;
+      max-height: 650px;
       object-fit: contain;
     }
   }
@@ -100,8 +100,8 @@ body:has(.tab-selection.is-sticky) .tab-selection {
 @media screen and (min-width: 992px) and (max-width: 1200px) {
   .active[name="content"] {
     img {
-      max-width: 250px;
-      max-height: 300px;
+      max-width: 550px;
+      max-height: 700px;
       object-fit: contain;
     }
   }

--- a/mod_app/static/css/tabbed-area.css
+++ b/mod_app/static/css/tabbed-area.css
@@ -90,3 +90,23 @@ body:has(.tab-selection.is-sticky) .tab-selection {
     }
   }
 }
+
+@media screen and (min-width: 767px) and (max-width: 992px) {
+  .active[name="content"] {
+    img {
+      max-width: 500px;
+      max-height: 100% !important;
+      object-fit: contain;
+    }
+  }
+}
+
+@media screen and (min-width: 992px) and (max-width: 1200px) {
+  .active[name="content"] {
+    img {
+      max-width: 700px;
+      max-height: 100% !important;
+      object-fit: contain;
+    }
+  }
+}


### PR DESCRIPTION
Some minor fixes
- In analyses detail page, add restraint on the maximum image size based on common device viewports
- Disable sticky for left columnar area so that in case of overflow-x (which shouldn't really be happening), the left column won't break the layout and eat into the right tab area column

I've also updated the adding image page of the wiki about the problem with image failing to wrap when placed inside a table, Analysis 6 on also needs the researchers to manually to add new footnote in place of the anchor link since converting to footnote doesn't seem to be doing its magic 😢        