### PR TITLE
Break very long words so that it doesn't cause overflow of tab content

### DIFF
--- a/mod_app/static/css/tabbed-area.css
+++ b/mod_app/static/css/tabbed-area.css
@@ -55,6 +55,7 @@ body:has(.tab-selection.is-sticky) .tab-selection {
     display: flex;
     flex-direction: column;
     object-fit: contain;
+    word-break: break-word;
   }
 
   section.footnotes {


### PR DESCRIPTION
Before:

(Extremely long words can cause contents to overflow the css grid width)

<img width="1831" height="471" alt="image" src="https://github.com/user-attachments/assets/904c9e49-09ad-4b6a-b78f-2d76db59e256" />

After adding word-break:
<img width="1823" height="524" alt="image" src="https://github.com/user-attachments/assets/60b5de82-9902-4e09-8231-ddf83ba327b1" />
