### PR TITLE
workaround download prevention

### DIFF
--- a/mod_app/static/js/main.js
+++ b/mod_app/static/js/main.js
@@ -1,11 +1,12 @@
-import { logToConsole } from "../second.js";
 import { setTagColours } from "./dynamicTagColours.js";
 import { prevSlide, nextSlide } from "./carousel.js";
+import { addPreventMenuListener } from "./preventMenu.js";
 
 setTagColours();
 
 document.addEventListener("DOMContentLoaded", function () {
   // const lightDarkToggle = document.querySelector(".toggle-container");
+  addPreventMenuListener();
   // lightDarkToggle.addEventListener("click", toggleMode());
   // function toggleMode() {
   // 	const body = document.body;

--- a/mod_app/static/js/main.js
+++ b/mod_app/static/js/main.js
@@ -6,7 +6,6 @@ setTagColours();
 
 document.addEventListener("DOMContentLoaded", function () {
   // const lightDarkToggle = document.querySelector(".toggle-container");
-  addPreventMenuListener();
   // lightDarkToggle.addEventListener("click", toggleMode());
   // function toggleMode() {
   // 	const body = document.body;
@@ -17,6 +16,8 @@ document.addEventListener("DOMContentLoaded", function () {
   // 	body.classList.remove(currentMode);
   // 	body.classList.add(currentMode);
   // }
+
+  addPreventMenuListener();
 
   if (document.querySelector(".carousel")) {
     const carouselButtonNext = document.querySelector(".carousel__buttons--next");

--- a/mod_app/static/js/preventMenu.js
+++ b/mod_app/static/js/preventMenu.js
@@ -1,0 +1,11 @@
+export function addPreventMenuListener() {
+  document.querySelectorAll("img, video").forEach(function (element) {
+    document.addEventListener(
+      "contextmenu",
+      function (e) {
+        e.preventDefault();
+      },
+      false,
+    );
+  });
+}

--- a/mod_app/templates/foundation.html
+++ b/mod_app/templates/foundation.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
 <!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
 <!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
@@ -22,7 +22,7 @@
     <script src="https://unpkg.com/htmx.org@1.9.11/dist/htmx.js" integrity="sha384-l9bYT9SL4CAW0Hl7pAOpfRc18mys1b0wK4U8UtGnWOxPVbVMgrOdB+jyz/WY8Jue" crossorigin="anonymous"></script>
     {% endcomment %}
   </head>
-  {% block body %}
-    <body></body>
-  {% endblock %}
+  <body>
+    {% block body %} {% endblock %}
+  </body>
 </html>


### PR DESCRIPTION
closes #88 

Whilst it's not necessarily what we originally envisaged, this will make it very difficult for users to select images and videos and download them since they should not be able to right click on any media with this PR

as a result, I think we can close #192 since I don't think it'll make things any more difficult to download things and would require more setup